### PR TITLE
Fix CollisionEngine reference error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/public/Ball.js
+++ b/public/Ball.js
@@ -15,3 +15,8 @@ export default class Ball {
         this.motion.updateBall(this);
     }
 }
+
+// Expose class globally for non-module environments
+if (typeof window !== 'undefined') {
+    window.Ball = Ball;
+}

--- a/public/board.js
+++ b/public/board.js
@@ -51,3 +51,8 @@ export default class Board {
         ctx.restore();
     }
 }
+
+// Expose class globally for non-module environments
+if (typeof window !== 'undefined') {
+    window.Board = Board;
+}

--- a/public/collision.js
+++ b/public/collision.js
@@ -169,3 +169,8 @@ export default class CollisionEngine {
         return false;
     }
 }
+
+// Expose class globally for non-module environments
+if (typeof window !== 'undefined') {
+    window.CollisionEngine = CollisionEngine;
+}

--- a/public/motion.js
+++ b/public/motion.js
@@ -16,3 +16,8 @@ export default class MotionEngine {
         }
     }
 }
+
+// Expose class globally for non-module environments
+if (typeof window !== 'undefined') {
+    window.MotionEngine = MotionEngine;
+}

--- a/test/collision.test.js
+++ b/test/collision.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import CollisionEngine from '../public/collision.js';
+import test from 'node:test';
+
+test('isPointInsidePolygon returns false for point far outside', () => {
+  const engine = new CollisionEngine(0, 0, 10, 4);
+  assert.equal(engine.isPointInsidePolygon(20, 0), false);
+});
+
+test('checkCollision detects edge collision', () => {
+  const engine = new CollisionEngine(0, 0, 10, 4);
+  const ball = { x: 10.5, y: 0, vx: 0, vy: 0, radius: 2 };
+  const col = engine.checkCollision(ball);
+  assert.ok(col);
+  assert.ok(col.penetration > 0);
+  assert.equal(Math.round(col.point.x), 10);
+});

--- a/test/motion.test.js
+++ b/test/motion.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import MotionEngine from '../public/motion.js';
+import test from 'node:test';
+
+test('updateBall applies gravity and updates position', () => {
+  const engine = new MotionEngine(1);
+  const ball = { x: 0, y: 0, vx: 2, vy: 3 };
+  engine.updateBall(ball);
+  assert.equal(ball.vy, 4);
+  assert.equal(ball.x, 2);
+  assert.equal(ball.y, 4);
+});
+
+test('updateRotation increments rotation', () => {
+  const engine = new MotionEngine(0, 0.1);
+  const obj = { rotation: 1 };
+  engine.updateRotation(obj);
+  assert.equal(obj.rotation, 1.1);
+});


### PR DESCRIPTION
## Summary
- expose game component classes on `window` for older browsers
- add a simple test suite for the motion and collision engines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d07bf853083209b599f9de06131d7