### PR TITLE
Move paddles to octagon edge

### DIFF
--- a/public/board.js
+++ b/public/board.js
@@ -10,6 +10,10 @@ export default class Board {
         this.paddleRotation = 0;
         this.paddleLength = this.radius * 0.4;
         this.paddleWidth = 10;
+        this.paddleDistance = Math.max(
+            this.radius - this.paddleLength / 2 - 20,
+            0
+        );
         this.vertices = this.collisionEngine.vertices;
     }
 
@@ -54,13 +58,22 @@ export default class Board {
             ctx.stroke();
         }
 
-        // draw rotating paddles
+        // draw rotating paddles around the octagon edge
         ctx.save();
         ctx.rotate(this.paddleRotation);
         ctx.fillStyle = '#999';
-        ctx.fillRect(-this.paddleLength / 2, -this.paddleWidth / 2, this.paddleLength, this.paddleWidth);
-        ctx.rotate(Math.PI / 2);
-        ctx.fillRect(-this.paddleLength / 2, -this.paddleWidth / 2, this.paddleLength, this.paddleWidth);
+        for (let i = 0; i < 4; i++) {
+            ctx.save();
+            ctx.rotate(i * Math.PI / 2);
+            ctx.translate(this.paddleDistance, 0);
+            ctx.fillRect(
+                -this.paddleLength / 2,
+                -this.paddleWidth / 2,
+                this.paddleLength,
+                this.paddleWidth
+            );
+            ctx.restore();
+        }
         ctx.restore();
 
         ctx.restore();

--- a/public/collision.js
+++ b/public/collision.js
@@ -7,6 +7,10 @@ export default class CollisionEngine {
         this.rotation = 0;
         this.paddleRotation = 0;
         this.paddleLength = this.radius * 0.4;
+        this.paddleDistance = Math.max(
+            this.radius - this.paddleLength / 2 - 20,
+            0
+        );
         this.vertices = this.generateVertices();
         this.edges = this.generateEdges();
         this.paddleEdges = this.generatePaddleEdges();
@@ -56,10 +60,13 @@ export default class CollisionEngine {
     }
 
     generatePaddleEdges() {
-        const l = this.paddleLength / 2;
+        const half = this.paddleLength / 2;
+        const d = this.paddleDistance;
         return [
-            { start: { x: -l, y: 0 }, end: { x: l, y: 0 } },
-            { start: { x: 0, y: -l }, end: { x: 0, y: l } }
+            { start: { x: d - half, y: 0 }, end: { x: d + half, y: 0 } },
+            { start: { x: 0, y: d - half }, end: { x: 0, y: d + half } },
+            { start: { x: -d - half, y: 0 }, end: { x: -d + half, y: 0 } },
+            { start: { x: 0, y: -d - half }, end: { x: 0, y: -d + half } }
         ];
     }
 
@@ -89,8 +96,9 @@ export default class CollisionEngine {
     }
 
     getRotatedPaddleEdges() {
-        const cos = Math.cos(this.paddleRotation);
-        const sin = Math.sin(this.paddleRotation);
+        const total = this.rotation + this.paddleRotation;
+        const cos = Math.cos(total);
+        const sin = Math.sin(total);
         return this.paddleEdges.map(e => {
             const start = {
                 x: e.start.x * cos - e.start.y * sin,


### PR DESCRIPTION
## Summary
- keep paddles near the border instead of the centre
- rotate paddle physics with board rotation
- keep behaviour stable for small boards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3cddc4e4832094007c4320c1c36e