### PR TITLE
Improve collision system and sync paddle rotation

### DIFF
--- a/public/Ball.js
+++ b/public/Ball.js
@@ -1,5 +1,8 @@
-export default class Ball {
+import CollisionObject from './collisionObject.js';
+
+export default class Ball extends CollisionObject {
     constructor(x, y, motionEngine, collisionEngine, options = {}) {
+        super(options.handle || `ball-${Date.now()}-${Math.random()}`, collisionEngine);
         this.x = x;
         this.y = y;
         this.vx = options.vx ?? 0;

--- a/public/board.js
+++ b/public/board.js
@@ -1,5 +1,8 @@
-export default class Board {
+import CollisionObject from './collisionObject.js';
+
+export default class Board extends CollisionObject {
     constructor(centerX, centerY, radius, sides, motionEngine, collisionEngine) {
+        super('board', collisionEngine);
         this.centerX = centerX;
         this.centerY = centerY;
         this.radius = radius;
@@ -19,7 +22,8 @@ export default class Board {
 
     update() {
         this.motion.updateRotation(this);
-        this.paddleRotation += this.motion.rotationSpeed;
+        // Keep paddles aligned with the board so they rotate at the same speed
+        this.paddleRotation = 0;
         this.collisionEngine.setRotation(this.rotation);
         this.collisionEngine.setPaddleRotation(this.paddleRotation);
     }

--- a/public/collision.js
+++ b/public/collision.js
@@ -14,6 +14,19 @@ export default class CollisionEngine {
         this.vertices = this.generateVertices();
         this.edges = this.generateEdges();
         this.paddleEdges = this.generatePaddleEdges();
+        this.objects = new Map();
+    }
+
+    registerObject(handle, obj) {
+        this.objects.set(handle, obj);
+    }
+
+    unregisterObject(handle) {
+        this.objects.delete(handle);
+    }
+
+    getObject(handle) {
+        return this.objects.get(handle);
     }
 
     setRotation(angle) {
@@ -217,6 +230,40 @@ export default class CollisionEngine {
         }
         
         return false;
+    }
+
+    checkBallBallCollision(a, b) {
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < a.radius + b.radius) {
+            return {
+                point: {
+                    x: (a.x + b.x) / 2,
+                    y: (a.y + b.y) / 2
+                },
+                normal: {
+                    x: dx / dist,
+                    y: dy / dist
+                },
+                penetration: a.radius + b.radius - dist
+            };
+        }
+        return null;
+    }
+
+    checkCollisionByHandle(ballHandle, targetHandle) {
+        const ball = this.getObject(ballHandle);
+        const target = this.getObject(targetHandle);
+        if (!ball || !target) return null;
+
+        if (targetHandle === 'board') {
+            return this.checkCollision(ball);
+        }
+        if (target.radius !== undefined) {
+            return this.checkBallBallCollision(ball, target);
+        }
+        return null;
     }
     
     constrainBall(ball) {

--- a/public/collisionObject.js
+++ b/public/collisionObject.js
@@ -1,0 +1,14 @@
+export default class CollisionObject {
+    constructor(handle, collisionEngine) {
+        this.handle = handle;
+        this.collisionEngine = collisionEngine;
+        if (collisionEngine && handle) {
+            collisionEngine.registerObject(handle, this);
+        }
+    }
+}
+
+// Expose class globally for non-module environments
+if (typeof window !== 'undefined') {
+    window.CollisionObject = CollisionObject;
+}

--- a/public/game.js
+++ b/public/game.js
@@ -133,7 +133,7 @@ class BouncingBallGame {
     }
 
     checkOctagonCollision(ball) {
-        const collision = this.collisionEngine.checkCollision(ball);
+        const collision = this.collisionEngine.checkCollisionByHandle(ball.handle, 'board');
 
         if (collision) {
             const bounced = this.collisionEngine.resolveCollision(ball, collision, ball.friction);


### PR DESCRIPTION
## Summary
- keep paddles aligned with the board so they rotate at the same speed
- register physical objects using new `CollisionObject` class
- add handle based lookup in `CollisionEngine`
- update `Ball` and `Board` to use handles
- detect collisions by handle in the game loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3fb160e88320bd23b122b10f2e3e