### PR TITLE
Fix paddle offset so balls can't fall through

### DIFF
--- a/public/board.js
+++ b/public/board.js
@@ -13,8 +13,12 @@ export default class Board extends CollisionObject {
         this.paddleRotation = 0;
         this.paddleLength = this.radius * 0.4;
         this.paddleWidth = 10;
+        // Position paddles flush with the octagon edge so balls can't slip
+        // between paddle and board. Previously the paddles were offset by
+        // 20 pixels which created a noticeable gap. Moving them outward
+        // aligns the outer edge of the paddle with the board radius.
         this.paddleDistance = Math.max(
-            this.radius - this.paddleLength / 2 - 20,
+            this.radius - this.paddleLength / 2,
             0
         );
         this.vertices = this.collisionEngine.vertices;

--- a/public/collision.js
+++ b/public/collision.js
@@ -7,8 +7,11 @@ export default class CollisionEngine {
         this.rotation = 0;
         this.paddleRotation = 0;
         this.paddleLength = this.radius * 0.4;
+        // Keep paddle edges aligned with the board boundary. Removing the
+        // previous 20px offset prevents balls from slipping between the
+        // paddles and the octagon.
         this.paddleDistance = Math.max(
-            this.radius - this.paddleLength / 2 - 20,
+            this.radius - this.paddleLength / 2,
             0
         );
         this.vertices = this.generateVertices();


### PR DESCRIPTION
## Summary
- keep paddles aligned with the board edge
- ensure collision engine uses the same distance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d492c7c90832085c698b7066ba16c