### PR TITLE
Fix missed collisions for fast balls

### DIFF
--- a/public/Ball.js
+++ b/public/Ball.js
@@ -12,9 +12,13 @@ export default class Ball extends CollisionObject {
         this.motion = motionEngine;
         this.collisionEngine = collisionEngine;
         this.friction = options.friction ?? 0.9;
+        this.prevX = x;
+        this.prevY = y;
     }
 
     update() {
+        this.prevX = this.x;
+        this.prevY = this.y;
         this.motion.updateBall(this);
     }
 }

--- a/public/collision.js
+++ b/public/collision.js
@@ -213,6 +213,30 @@ export default class CollisionEngine {
         
         return collision;
     }
+
+    checkContinuousCollision(ball, prevX, prevY) {
+        const nextX = ball.x;
+        const nextY = ball.y;
+        const dx = nextX - prevX;
+        const dy = nextY - prevY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        const steps = Math.max(Math.ceil(distance / (ball.radius || 1)), 1);
+        const stepX = dx / steps;
+        const stepY = dy / steps;
+        const temp = { x: prevX, y: prevY, vx: ball.vx, vy: ball.vy, radius: ball.radius };
+
+        for (let i = 1; i <= steps; i++) {
+            temp.x += stepX;
+            temp.y += stepY;
+            const col = this.checkCollision(temp);
+            if (col) {
+                ball.x = temp.x;
+                ball.y = temp.y;
+                return col;
+            }
+        }
+        return null;
+    }
     
     resolveCollision(ball, collision, friction = 0.9) {
         if (!collision) return false;

--- a/public/game.js
+++ b/public/game.js
@@ -33,6 +33,9 @@ class BouncingBallGame {
 
         // Minimum velocity magnitude required to play a bounce sound
         this.soundThreshold = 1;
+        // Velocity magnitude above which collisions are checked along the
+        // movement path to avoid tunneling
+        this.continuousCollisionThreshold = 12;
         this.createBall();
 
         this.initAudio();
@@ -131,6 +134,23 @@ class BouncingBallGame {
     updatePhysics() {
         for (const ball of this.balls) {
             ball.update();
+            const speed = Math.hypot(ball.vx, ball.vy);
+            if (speed > this.continuousCollisionThreshold) {
+                const col = this.collisionEngine.checkContinuousCollision(
+                    ball,
+                    ball.prevX,
+                    ball.prevY
+                );
+                if (col) {
+                    const bounced = this.collisionEngine.resolveCollision(ball, col, ball.friction);
+                    if (bounced) {
+                        const after = Math.hypot(ball.vx, ball.vy);
+                        if (after > this.soundThreshold) {
+                            this.playBounceSound(Math.min(after / 10, 1));
+                        }
+                    }
+                }
+            }
             this.checkOctagonCollision(ball);
         }
 

--- a/test/collision.test.js
+++ b/test/collision.test.js
@@ -23,3 +23,13 @@ test('rotation affects collision detection', () => {
   const col = engine.checkCollision(ball);
   assert.ok(col);
 });
+
+test('checkContinuousCollision catches fast movement', () => {
+  const engine = new CollisionEngine(0, 0, 10, 4);
+  const ball = { x: -15, y: 0, vx: 30, vy: 0, radius: 2 };
+  const prevX = ball.x;
+  const prevY = ball.y;
+  ball.x += ball.vx;
+  const col = engine.checkContinuousCollision(ball, prevX, prevY);
+  assert.ok(col);
+});


### PR DESCRIPTION
## Summary
- add previous position tracking on `Ball`
- implement `CollisionEngine.checkContinuousCollision`
- check the movement path for collisions in `game.js`
- add regression test for continuous collision detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e7d686a648320b3444bb879e0e10a