### PR TITLE
Add angled bounce behavior to random mode

### DIFF
--- a/public/randomNumber.js
+++ b/public/randomNumber.js
@@ -30,16 +30,32 @@ export default class RandomNumberGame {
                 this.obstacles.push({ x, y, radius: 10 });
             }
         }
+        // extra obstacle above the first slot so the ball can bounce on the far left
+        const slotWidth = this.canvas.width / 25;
+        const extraY = 50 + spacingY;
+        this.obstacles.push({ x: slotWidth / 2, y: extraY, radius: 10 });
+
+        // small posts forming boxes above each number
+        const postY = this.canvas.height - this.slotHeight - 10;
+        for (let i = 0; i < 25; i++) {
+            const leftX = i * slotWidth + 4;
+            const rightX = (i + 1) * slotWidth - 4;
+            this.obstacles.push({ x: leftX, y: postY, radius: 5 });
+            this.obstacles.push({ x: rightX, y: postY, radius: 5 });
+        }
     }
 
     spawnBall() {
         const spacingX = this.canvas.width / (12 + 1);
         const margin = spacingX / 2;
+        const speed = 3;
+        const angle = Math.PI / 6; // 30 degrees from vertical
+        const dir = Math.random() < 0.5 ? -1 : 1;
         this.ball = {
             x: margin + Math.random() * (this.canvas.width - margin * 2),
             y: -20,
-            vx: (Math.random() - 0.5) * 2,
-            vy: 0,
+            vx: dir * speed * Math.sin(angle),
+            vy: speed * Math.cos(angle),
             radius: 10,
             color: '#ff6b6b'
         };
@@ -77,16 +93,18 @@ export default class RandomNumberGame {
             const dy = this.ball.y - o.y;
             const dist = Math.hypot(dx, dy);
             if (dist < this.ball.radius + o.radius) {
+                const penetration = this.ball.radius + o.radius - dist;
                 const nx = dx / dist;
                 const ny = dy / dist;
-                const penetration = this.ball.radius + o.radius - dist;
                 this.ball.x += nx * penetration;
                 this.ball.y += ny * penetration;
-                const dot = this.ball.vx * nx + this.ball.vy * ny;
-                this.ball.vx -= 2 * dot * nx;
-                this.ball.vy -= 2 * dot * ny;
-                this.ball.vx *= 0.9;
-                this.ball.vy *= 0.9;
+
+                // after hitting a peg, deflect 30 degrees left or right
+                const speed = Math.hypot(this.ball.vx, this.ball.vy) || 1;
+                const angle = Math.PI / 6;
+                const dir = Math.random() < 0.5 ? -1 : 1;
+                this.ball.vx = dir * speed * Math.sin(angle);
+                this.ball.vy = Math.abs(speed * Math.cos(angle));
             }
         }
     }


### PR DESCRIPTION
## Summary
- make the random number mode keep the ball from going straight down by deflecting 30° left or right
- spawn new balls with a 30° initial direction
- add extra peg above the first slot
- create post obstacles so the ball must roll into a small bin above each number

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e893159f88320b9caebaa83973ff7