### PR TITLE
Add in-game statistics popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
 </head>
 <body>
     <a id="githubBadge" href="https://github.com/casparjones/ball">clone on github</a>
+    <button id="statsButton" style="position:absolute;top:10px;right:120px;z-index:10;">Show Statistik</button>
+    <div id="statsPopup" style="display:none;position:absolute;top:40px;right:10px;background:rgba(0,0,0,0.8);color:#fff;padding:10px;border-radius:4px;font-size:12px;"></div>
     <div id="gameContainer">
         <h1 style="text-align:center;color:white;">Realistic Ball Bump Experiment</h1>
         <select id="modeSelect" style="display:block;margin:10px auto;">

--- a/public/index.php
+++ b/public/index.php
@@ -12,6 +12,8 @@ $canvasHeight = 800;
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <button id="statsButton" style="position:absolute;top:10px;right:120px;z-index:10;">Show Statistik</button>
+    <div id="statsPopup" style="display:none;position:absolute;top:40px;right:10px;background:rgba(0,0,0,0.8);color:#fff;padding:10px;border-radius:4px;font-size:12px;"></div>
     <div id="gameContainer">
         <select id="modeSelect" style="display:block;margin:10px auto;">
             <option value="carousel">Carousel</option>

--- a/public/main.js
+++ b/public/main.js
@@ -3,7 +3,18 @@ import RandomNumberGame from './randomNumber.js';
 
 const modeSelect = document.getElementById('modeSelect');
 const canvas = document.getElementById('gameCanvas');
+const statsButton = document.getElementById('statsButton');
+const statsPopup = document.getElementById('statsPopup');
 let currentGame = null;
+
+function toggleStats() {
+    if (currentGame && currentGame.toggleStats) {
+        const visible = currentGame.toggleStats();
+        statsPopup.style.display = visible ? 'block' : 'none';
+    }
+}
+
+statsButton.addEventListener('click', toggleStats);
 
 function start(mode) {
     if (currentGame && currentGame.destroy) {
@@ -11,8 +22,12 @@ function start(mode) {
     }
     if (mode === 'random') {
         currentGame = new RandomNumberGame(canvas);
+        statsButton.style.display = 'block';
+        statsPopup.style.display = 'none';
     } else {
         currentGame = new BouncingBallGame(canvas);
+        statsButton.style.display = 'none';
+        statsPopup.style.display = 'none';
     }
 }
 

--- a/public/randomNumber.js
+++ b/public/randomNumber.js
@@ -8,6 +8,9 @@ export default class RandomNumberGame {
         this.ball = null;
         this.obstacles = [];
         this.result = null;
+        this.stats = Array(25).fill(0);
+        this.showStats = false;
+        this.statsPopup = document.getElementById('statsPopup');
         this.slotHeight = 40;
         this.createObstacles();
         this.spawnBall();
@@ -78,6 +81,7 @@ export default class RandomNumberGame {
             const slotWidth = this.canvas.width / 25;
             const index = Math.floor(this.ball.x / slotWidth) + 1;
             this.result = index;
+            this.stats[index - 1] += 1;
             this.ball.vx = 0;
             this.ball.vy = 0;
             this.ball.y = this.canvas.height - this.slotHeight - this.ball.radius;
@@ -157,9 +161,30 @@ export default class RandomNumberGame {
         }
     }
 
+    updateStatsPopup() {
+        if (!this.showStats || !this.statsPopup) return;
+        const arr = this.stats.map((c, i) => ({ number: i + 1, count: c }));
+        arr.sort((a, b) => b.count - a.count);
+        const top = arr.filter(a => a.count > 0).slice(0, 5);
+        let html = '<strong>Top Zahlen</strong><br>';
+        for (const t of top) {
+            html += `${t.number}: ${t.count}<br>`;
+        }
+        html += '<hr>';
+        html += `pos: ${Math.round(this.ball.x)},${Math.round(this.ball.y)}<br>`;
+        html += `vel: ${this.ball.vx.toFixed(2)},${this.ball.vy.toFixed(2)}`;
+        this.statsPopup.innerHTML = html;
+    }
+
+    toggleStats() {
+        this.showStats = !this.showStats;
+        return this.showStats;
+    }
+
     animate() {
         this.updateBall();
         this.draw();
+        this.updateStatsPopup();
         this.animationId = requestAnimationFrame(this.animate);
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -17,3 +17,23 @@ canvas {
     border: 2px solid #333;
     background-color: #000;
 }
+
+#statsButton {
+    position: absolute;
+    top: 10px;
+    right: 120px;
+    z-index: 10;
+}
+
+#statsPopup {
+    position: absolute;
+    top: 40px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    display: none;
+    min-width: 120px;
+}


### PR DESCRIPTION
## Summary
- add a button and popup container to display number statistics
- update CSS for new UI elements
- manage statistic visibility in main.js
- track results and display top hits with ball data in randomNumber.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e93eae33c8320b4797aa07eca1083