### PR TITLE
Implement drum helper and cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,12 @@ Eine Live-Demo ist unter <https://casparjones.github.io/ball/> verfügbar.
 - Simuliert eine Lotto-Ziehung mit 49 nummerierten Kugeln
 - Zieht nacheinander sechs Kugeln und zeigt sie am Rand an
 
-#### CollisionEngine (`collision.js`)
-- Spezialisierte Physik-Engine für Polygon-Kollisionen
-- Implementiert SAT (Separating Axis Theorem) für präzise Kollisionsdetektion
-- Behandelt sowohl Kanten- als auch Eckenkollisionen
-- Verwaltet Ball-Beschränkungen innerhalb des Oktagons
 
 ### Physik-Simulation
 - **Schwerkraft**: 0.4 Pixel/Frame²
 - **Reibung**: 90% Geschwindigkeitserhaltung bei Kollisionen
 - **Elastische Kollisionen**: Realistische Reflexion basierend auf Oberflächennormalen
-- **Kontinuierliche Rotation**: 0.01 Radiant/Frame
+- **Kontinuierliche Rotation**: 0.01 Radian/Frame
 
 ## Installation
 
@@ -93,7 +88,6 @@ Eine Live-Demo ist unter <https://casparjones.github.io/ball/> verfügbar.
 css/                # Styling und Layout
 js/                 # Sämtliche Spiel- und Hilfs-Skripte
 img/                # Grafiken und Screenshots
-php/                # PHP-Hilfsdateien
 index.html          # Einstiegspunkt der Anwendung
 ```
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 </head>
 <body>
     <a id="githubBadge" href="https://github.com/casparjones/ball">clone on github</a>
-    <span id="version" style="position:absolute;top:10px;right:90px;color:#fff;font-size:14px;"></span>
+    <span id="version" style="position:absolute;bottom:10px;right:10px;color:#fff;font-size:14px;"></span>
     <button id="statsButton" style="position:absolute;top:10px;right:120px;z-index:10;">Show Statistik</button>
     <div id="statsPopup" style="display:none;position:absolute;top:40px;right:10px;background:rgba(0,0,0,0.8);color:#fff;padding:10px;border-radius:4px;font-size:12px;"></div>
     <div id="gameContainer">
@@ -33,17 +33,11 @@
         </select>
         <canvas id="gameCanvas" width="800" height="800"></canvas>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.20.0/matter.min.js" integrity="sha512-6+7rTBmR6pRFe9fa0vCFjFaHZj/XYa7774bEBzRtxgdpIJOS++R3cKd6Prg/eJmxtsJotd8KAg4g57uuVQsZKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script type="module" src="js/main.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.20.0/matter.min.js?v=05834889817690967839998344003691" integrity="sha512-6+7rTBmR6pRFe9fa0vCFjFaHZj/XYa7774bEBzRtxgdpIJOS++R3cKd6Prg/eJmxtsJotd8KAg4g57uuVQsZKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script>
-        const d = new Date();
-        const pad = n => n.toString().padStart(2, '0');
-        const version = d.getFullYear().toString() +
-            pad(d.getMonth() + 1) +
-            pad(d.getDate()) +
-            pad(d.getHours()) +
-            pad(d.getMinutes());
+        const version = '05834889817690967839998344003691';
         document.getElementById('version').textContent = version;
     </script>
+    <script type="module" src="js/main.js?v=05834889817690967839998344003691"></script>
 </body>
 </html>

--- a/js/drum.js
+++ b/js/drum.js
@@ -1,0 +1,33 @@
+import { Matter, addBody } from './physics.js';
+
+export function createDrum(engine, centerX, centerY, radius, options = {}) {
+    const walls = [];
+    const sides = 8;
+    const thickness = options.thickness || 20;
+    const angleStep = Math.PI * 2 / sides;
+    const wallLength = 2 * radius * Math.sin(angleStep / 2);
+    const wallDistance = radius * Math.cos(angleStep / 2);
+
+    for (let i = 0; i < sides; i++) {
+        const angle = i * angleStep + angleStep / 2;
+        const x = centerX + Math.cos(angle) * wallDistance;
+        const y = centerY + Math.sin(angle) * wallDistance;
+        const wall = Matter.Bodies.rectangle(x, y, wallLength, thickness, { isStatic: true, ...options });
+        wall.baseAngle = angle;
+        wall.distance = wallDistance;
+        Matter.Body.setAngle(wall, angle);
+        addBody(engine, wall);
+        walls.push(wall);
+    }
+    return walls;
+}
+
+export function rotateDrum(walls, centerX, centerY, delta) {
+    for (const wall of walls) {
+        wall.baseAngle += delta;
+        const x = centerX + Math.cos(wall.baseAngle) * wall.distance;
+        const y = centerY + Math.sin(wall.baseAngle) * wall.distance;
+        Matter.Body.setPosition(wall, { x, y });
+        Matter.Body.setAngle(wall, wall.baseAngle);
+    }
+}

--- a/js/game.js
+++ b/js/game.js
@@ -1,5 +1,6 @@
 import { createEngine, updateEngine, addBody, Matter } from './physics.js';
 import Ball from './ball.js';
+import { createDrum, rotateDrum } from './drum.js';
 
 export default class BouncingBallGame {
     constructor(canvas = document.getElementById('gameCanvas')) {
@@ -11,7 +12,6 @@ export default class BouncingBallGame {
         this.engine = createEngine(0.6);
         this.createBoard();
         this.rotationSpeed = 0.01;
-        this.boardAngle = 0;
         this.balls = [];
         this.createObstacles();
         this.addBall(this.centerX, this.centerY);
@@ -20,22 +20,7 @@ export default class BouncingBallGame {
     }
 
     createBoard() {
-        this.board = [];
-        this.sides = 8;
-        this.wallThickness = 20;
-        this.angleStep = Math.PI * 2 / this.sides;
-        this.wallDistance = this.radius * Math.cos(this.angleStep / 2);
-        this.wallLength = 2 * this.radius * Math.sin(this.angleStep / 2);
-        for (let i = 0; i < this.sides; i++) {
-            const angle = i * this.angleStep + this.angleStep / 2;
-            const x = this.centerX + Math.cos(angle) * this.wallDistance;
-            const y = this.centerY + Math.sin(angle) * this.wallDistance;
-            const wall = Matter.Bodies.rectangle(x, y, this.wallLength, this.wallThickness, { isStatic: true });
-            wall.baseAngle = angle;
-            Matter.Body.setAngle(wall, angle);
-            addBody(this.engine, wall);
-            this.board.push(wall);
-        }
+        this.board = createDrum(this.engine, this.centerX, this.centerY, this.radius, { thickness: 20 });
     }
 
     createObstacles() {
@@ -79,14 +64,7 @@ export default class BouncingBallGame {
     }
 
     update() {
-        this.boardAngle += this.rotationSpeed;
-        for (const wall of this.board) {
-            const angle = wall.baseAngle + this.boardAngle;
-            const x = this.centerX + Math.cos(angle) * this.wallDistance;
-            const y = this.centerY + Math.sin(angle) * this.wallDistance;
-            Matter.Body.setPosition(wall, { x, y });
-            Matter.Body.setAngle(wall, angle);
-        }
+        rotateDrum(this.board, this.centerX, this.centerY, this.rotationSpeed);
         const distance = this.radius - 20;
         for (const o of this.obstacles) {
             o.offsetAngle += this.rotationSpeed;


### PR DESCRIPTION
## Summary
- add 32-digit version string for cache busting and display at bottom-right
- new `drum.js` creates an octagonal drum of rectangles
- use new drum helper in the main game
- clean README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862be13307883209b139e13e6310829